### PR TITLE
Add Import & Export functionality

### DIFF
--- a/e2e/e2e-utils.ts
+++ b/e2e/e2e-utils.ts
@@ -189,6 +189,39 @@ export async function setupChromeMock(page: any, rootNode: any, mockMap: any = {
                         }
                         callback(JSON.parse(JSON.stringify(results)));
                     },
+                    create: (bookmark: any, callback: any) => {
+                        const newId = String(Math.floor(Math.random() * 1000000));
+                        const parentId = bookmark.parentId || '1'; // Default to Bookmarks Bar
+                        const newNode: any = {
+                            id: newId,
+                            title: bookmark.title || '',
+                            url: bookmark.url,
+                            parentId: parentId,
+                            index: bookmark.index,
+                            dateAdded: Date.now()
+                        };
+
+                        if (!bookmark.url) {
+                            newNode.children = [];
+                        }
+
+                        const parent = findNode(rootNodeArg, parentId);
+                        if (parent) {
+                            if (!parent.children) parent.children = [];
+                            if (typeof bookmark.index === 'number' && bookmark.index >= 0 && bookmark.index <= parent.children.length) {
+                                parent.children.splice(bookmark.index, 0, newNode);
+                            } else {
+                                parent.children.push(newNode);
+                            }
+
+                            // Normalize indices
+                            parent.children.forEach((c: any, i: number) => { c.index = i; });
+
+                            listeners.onCreated.forEach((l: any) => l(newId, newNode));
+                        }
+
+                        if (callback) callback(JSON.parse(JSON.stringify(newNode)));
+                    },
                     move: (id: string, destination: any, callback?: any) => {
                         moveNode(id, destination);
                         if (callback) callback(JSON.parse(JSON.stringify(findNode(rootNodeArg, id))));

--- a/e2e/import-export.spec.ts
+++ b/e2e/import-export.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test';
+import { getMockData, setupChromeMock } from './e2e-utils';
+
+test.describe('Import & Export', () => {
+  let mockData: ReturnType<typeof getMockData>;
+
+  test.beforeEach(async ({ page }) => {
+    mockData = getMockData();
+    await setupChromeMock(page, mockData.root, mockData.MOCK_BOOKMARKS_MAP);
+    await page.goto('/#/settings/import-export');
+  });
+
+  test('should navigate to import-export page', async ({ page }) => {
+    await expect(page.locator('.settings-container h2')).toContainText('Import & Export');
+    await expect(page.getByText('Backup & Restore (JSON)')).toBeVisible();
+    await expect(page.getByText('Standard HTML Format')).toBeVisible();
+  });
+
+  test('should export JSON', async ({ page }) => {
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Export JSON' }).click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toContain('bookmarks_backup_');
+    expect(download.suggestedFilename()).toContain('.json');
+  });
+
+  test('should export HTML', async ({ page }) => {
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Export HTML' }).click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toContain('bookmarks_');
+    expect(download.suggestedFilename()).toContain('.html');
+  });
+
+  test('should import JSON', async ({ page }) => {
+    // Create a mock JSON file content
+    const backupData = {
+        version: 1,
+        root: [
+            {
+                id: '0',
+                children: [
+                    {
+                        id: '1', // Bar
+                        children: [
+                            {
+                                id: '1001',
+                                title: 'Imported JSON Bookmark',
+                                url: 'https://json.example.com'
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        tags: {}
+    };
+
+    // Trigger file chooser and set file
+    const fileChooserPromise = page.waitForEvent('filechooser');
+    await page.getByRole('button', { name: 'Import JSON' }).click();
+    const fileChooser = await fileChooserPromise;
+
+    await fileChooser.setFiles({
+        name: 'backup.json',
+        mimeType: 'application/json',
+        buffer: Buffer.from(JSON.stringify(backupData))
+    });
+
+    // Check success message
+    await expect(page.getByText('JSON Import successful')).toBeVisible();
+
+    // Verify it called create (indirectly via chrome mock check?)
+    // Actually, we can check if we can search for it?
+    // Or navigate to bookmarks view and check?
+    // The mock is in-memory in the page context.
+    // If I search in the app, I should find it.
+
+    // Let's go to main page and search
+    await page.getByRole('link', { name: '← Back to Bookmarks' }).click();
+
+    const searchBox = page.getByPlaceholder('Search in bookmarks');
+    await searchBox.fill('Imported JSON Bookmark');
+    await expect(page.getByText('Imported JSON Bookmark')).toBeVisible();
+  });
+
+  test('should import HTML', async ({ page }) => {
+    const htmlContent = `<!DOCTYPE NETSCAPE-Bookmark-file-1>
+    <DL>
+        <DT><A HREF="https://html.example.com">Imported HTML Bookmark</A>
+    </DL>`;
+
+    const fileChooserPromise = page.waitForEvent('filechooser');
+    await page.getByRole('button', { name: 'Import HTML' }).click();
+    const fileChooser = await fileChooserPromise;
+
+    await fileChooser.setFiles({
+        name: 'bookmarks.html',
+        mimeType: 'text/html',
+        buffer: Buffer.from(htmlContent)
+    });
+
+    await expect(page.getByText('HTML Import successful')).toBeVisible();
+
+    await page.getByRole('link', { name: '← Back to Bookmarks' }).click();
+
+    const searchBox = page.getByPlaceholder('Search in bookmarks');
+    await searchBox.fill('Imported HTML Bookmark');
+    await expect(page.getByText('Imported HTML Bookmark')).toBeVisible();
+  });
+});

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -22,6 +22,10 @@ export const routes: Routes = [
             {
                 path: 'ai',
                 loadComponent: () => import('./components/ai-settings/ai-settings.component').then(m => m.AiSettingsComponent)
+            },
+            {
+                path: 'import-export',
+                loadComponent: () => import('./components/settings/import-export/import-export.component').then(m => m.ImportExportComponent)
             }
         ]
     }

--- a/src/app/components/settings/import-export/import-export.component.css
+++ b/src/app/components/settings/import-export/import-export.component.css
@@ -6,7 +6,7 @@
 .section {
   margin-bottom: 30px;
   padding: 20px;
-  background: var(--surface-card);
+  background: var(--card-bg, #fff);
   border-radius: 8px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.1);
 }
@@ -17,7 +17,7 @@ h3 {
 }
 
 p {
-  color: var(--text-secondary);
+  color: var(--secondary-text-color, #666);
   margin-bottom: 20px;
 }
 
@@ -41,22 +41,23 @@ p {
 }
 
 .btn.primary {
-  background: var(--primary);
+  background: var(--primary-color, #1976d2);
   color: white;
 }
 
 .btn.primary:hover:not(:disabled) {
-  background: var(--primary-dark);
+  /* Simple darken effect using filter if variable not available, or just same color */
+  filter: brightness(0.9);
 }
 
 .btn.secondary {
-  background: var(--surface-hover);
-  color: var(--text-primary);
-  border: 1px solid var(--border-color);
+  background: var(--button-secondary-bg, #eee);
+  color: var(--text-color, #333);
+  border: 1px solid var(--border-color, #ccc);
 }
 
 .btn.secondary:hover:not(:disabled) {
-  background: var(--surface-active);
+  background: var(--button-secondary-hover, #ddd);
 }
 
 .message {

--- a/src/app/components/settings/import-export/import-export.component.css
+++ b/src/app/components/settings/import-export/import-export.component.css
@@ -1,0 +1,78 @@
+.settings-container {
+  padding: 20px;
+  max-width: 800px;
+}
+
+.section {
+  margin-bottom: 30px;
+  padding: 20px;
+  background: var(--surface-card);
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+h3 {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+p {
+  color: var(--text-secondary);
+  margin-bottom: 20px;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+}
+
+.btn {
+  padding: 8px 16px;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background 0.2s;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn.primary {
+  background: var(--primary);
+  color: white;
+}
+
+.btn.primary:hover:not(:disabled) {
+  background: var(--primary-dark);
+}
+
+.btn.secondary {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+}
+
+.btn.secondary:hover:not(:disabled) {
+  background: var(--surface-active);
+}
+
+.message {
+  padding: 10px 15px;
+  border-radius: 4px;
+  margin-top: 20px;
+}
+
+.message.success {
+  background: rgba(76, 175, 80, 0.1);
+  color: #4caf50;
+  border: 1px solid #4caf50;
+}
+
+.message.error {
+  background: rgba(244, 67, 54, 0.1);
+  color: #f44336;
+  border: 1px solid #f44336;
+}

--- a/src/app/components/settings/import-export/import-export.component.html
+++ b/src/app/components/settings/import-export/import-export.component.html
@@ -1,0 +1,29 @@
+<div class="settings-container">
+  <h2>Import & Export</h2>
+
+  <div class="section">
+    <h3>Backup & Restore (JSON)</h3>
+    <p>Export all bookmarks, folders, and tags to a JSON file. This format preserves all metadata.</p>
+    <div class="actions">
+      <button class="btn primary" (click)="exportJson()" [disabled]="isLoading">Export JSON</button>
+
+      <input type="file" #jsonInput style="display: none" accept=".json" (change)="onJsonFileSelected($event)">
+      <button class="btn secondary" (click)="jsonInput.click()" [disabled]="isLoading">Import JSON</button>
+    </div>
+  </div>
+
+  <div class="section">
+    <h3>Standard HTML Format</h3>
+    <p>Export bookmarks to a standard HTML file compatible with Chrome, Firefox, and other browsers.</p>
+    <div class="actions">
+      <button class="btn primary" (click)="exportHtml()" [disabled]="isLoading">Export HTML</button>
+
+      <input type="file" #htmlInput style="display: none" accept=".html" (change)="onHtmlFileSelected($event)">
+      <button class="btn secondary" (click)="htmlInput.click()" [disabled]="isLoading">Import HTML</button>
+    </div>
+  </div>
+
+  <div *ngIf="message" class="message" [ngClass]="messageType">
+    {{ message }}
+  </div>
+</div>

--- a/src/app/components/settings/import-export/import-export.component.ts
+++ b/src/app/components/settings/import-export/import-export.component.ts
@@ -1,0 +1,56 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ImportExportService } from '../../../services/import-export.service';
+
+@Component({
+  selector: 'app-import-export',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './import-export.component.html',
+  styleUrls: ['./import-export.component.css']
+})
+export class ImportExportComponent {
+  private importExportService = inject(ImportExportService);
+
+  isLoading = false;
+  message = '';
+  messageType: 'success' | 'error' = 'success';
+
+  exportJson() {
+    this.wrapAction(() => this.importExportService.exportJson(), 'JSON Export successful');
+  }
+
+  exportHtml() {
+    this.wrapAction(() => this.importExportService.exportHtml(), 'HTML Export successful');
+  }
+
+  onJsonFileSelected(event: Event) {
+    const file = (event.target as HTMLInputElement).files?.[0];
+    if (file) {
+      this.wrapAction(() => this.importExportService.importJson(file), 'JSON Import successful');
+    }
+  }
+
+  onHtmlFileSelected(event: Event) {
+    const file = (event.target as HTMLInputElement).files?.[0];
+    if (file) {
+      this.wrapAction(() => this.importExportService.importHtml(file), 'HTML Import successful');
+    }
+  }
+
+  private async wrapAction(action: () => Promise<void>, successMessage: string) {
+    this.isLoading = true;
+    this.message = '';
+    try {
+      await action();
+      this.message = successMessage;
+      this.messageType = 'success';
+    } catch (e: any) {
+      console.error(e);
+      this.message = 'Error: ' + (e.message || 'Unknown error');
+      this.messageType = 'error';
+    } finally {
+      this.isLoading = false;
+    }
+  }
+}

--- a/src/app/components/settings/settings.component.html
+++ b/src/app/components/settings/settings.component.html
@@ -10,6 +10,9 @@
       <a routerLink="/settings/ai" routerLinkActive="active" class="nav-item">
         AI Categorization
       </a>
+      <a routerLink="/settings/import-export" routerLinkActive="active" class="nav-item">
+        Import & Export
+      </a>
     </nav>
     <div class="sidebar-footer">
       <a routerLink="/" class="back-link">← Back to Bookmarks</a>

--- a/src/app/services/bookmarks-provider.service.ts
+++ b/src/app/services/bookmarks-provider.service.ts
@@ -44,6 +44,10 @@ export class BookmarksProviderService {
     return this.bookmarksService.search(searchTerm);
   }
 
+  public create(bookmark: chrome.bookmarks.BookmarkCreateArg): Promise<chrome.bookmarks.BookmarkTreeNode> {
+    return this.bookmarksService.create(bookmark);
+  }
+
   public filterDirectories(bookmarks: chrome.bookmarks.BookmarkTreeNode[]): chrome.bookmarks.BookmarkTreeNode[] {
     return bookmarks.filter((bookmark) => bookmark.url === undefined).map((bookmark) => {
       let newBookmark = Object.create(bookmark);

--- a/src/app/services/import-export.service.ts
+++ b/src/app/services/import-export.service.ts
@@ -1,0 +1,235 @@
+import { Injectable, inject } from '@angular/core';
+import { BookmarksProviderService } from './bookmarks-provider.service';
+import { TagsService, BookmarkTags } from './tags.service';
+
+export interface BackupData {
+  version: number;
+  root: chrome.bookmarks.BookmarkTreeNode[];
+  tags: BookmarkTags;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ImportExportService {
+  private bookmarksProvider = inject(BookmarksProviderService);
+  private tagsService = inject(TagsService);
+
+  constructor() { }
+
+  public async exportJson() {
+    const tree = await this.bookmarksProvider.getBookmarks();
+    const tags = this.tagsService.bookmarkTags();
+
+    const data: BackupData = {
+      version: 1,
+      root: tree,
+      tags: tags
+    };
+
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    this.downloadFile(blob, `bookmarks_backup_${new Date().toISOString().split('T')[0]}.json`);
+  }
+
+  public async importJson(file: File): Promise<void> {
+    const text = await file.text();
+    const data: BackupData = JSON.parse(text);
+
+    if (!data.root || !Array.isArray(data.root)) {
+      throw new Error('Invalid backup file format');
+    }
+
+    // Create a root folder for import
+    // '1' is typically Bookmarks Bar.
+    const importFolder = await this.bookmarksProvider.create({
+      parentId: '1',
+      title: `Imported ${new Date().toLocaleString()}`
+    });
+
+    const idMap = new Map<string, string>();
+
+    // data.root is [rootNode]. We want the children of rootNode (Bar, Other, etc)
+    const nodesToImport = data.root[0]?.children || data.root;
+
+    for (const node of nodesToImport) {
+        await this.recursiveImport(node, importFolder.id, idMap);
+    }
+
+    // Restore tags
+    if (data.tags) {
+        for (const [oldId, tags] of Object.entries(data.tags)) {
+            const newId = idMap.get(oldId);
+            if (newId) {
+                this.tagsService.setTagsForBookmark(newId, tags);
+                tags.forEach(tag => this.tagsService.addAvailableTag(tag));
+            }
+        }
+    }
+  }
+
+  private async recursiveImport(node: chrome.bookmarks.BookmarkTreeNode, parentId: string, idMap: Map<string, string>) {
+    const created = await this.bookmarksProvider.create({
+        parentId: parentId,
+        title: node.title,
+        url: node.url
+    });
+
+    idMap.set(node.id, created.id);
+
+    if (node.children) {
+        for (const child of node.children) {
+            await this.recursiveImport(child, created.id, idMap);
+        }
+    }
+  }
+
+  private downloadFile(blob: Blob, filename: string) {
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    window.URL.revokeObjectURL(url);
+  }
+
+  public async exportHtml() {
+    const tree = await this.bookmarksProvider.getBookmarks();
+    // tree is [root]. root children are Bar, Other.
+
+    let html = `<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<!-- This is an automatically generated file.
+     It will be read and overwritten.
+     DO NOT EDIT! -->
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+`;
+
+    const nodesToExport = tree[0]?.children || tree;
+    for (const node of nodesToExport) {
+        html += this.nodeToHtml(node, 1);
+    }
+
+    html += `</DL><p>`;
+
+    const blob = new Blob([html], { type: 'text/html' });
+    this.downloadFile(blob, `bookmarks_${new Date().toISOString().split('T')[0]}.html`);
+  }
+
+  private nodeToHtml(node: chrome.bookmarks.BookmarkTreeNode, indentLevel: number): string {
+      const indent = '    '.repeat(indentLevel);
+      let html = '';
+
+      if (node.url) {
+          const tags = this.tagsService.getTagsForBookmark(node.id);
+          const escapedTags = tags.map(t => this.escapeHtml(t)).join(',');
+          const tagsAttr = tags.length > 0 ? ` TAGS="${escapedTags}"` : '';
+          const addDate = node.dateAdded ? ` ADD_DATE="${Math.floor(node.dateAdded / 1000)}"` : '';
+
+          html += `${indent}<DT><A HREF="${this.escapeHtml(node.url)}"${addDate}${tagsAttr}>${this.escapeHtml(node.title)}</A>\n`;
+      } else {
+          // Folder
+          const addDate = node.dateAdded ? ` ADD_DATE="${Math.floor(node.dateAdded / 1000)}"` : '';
+          const lastMod = node.dateGroupModified ? ` LAST_MODIFIED="${Math.floor(node.dateGroupModified / 1000)}"` : '';
+
+          html += `${indent}<DT><H3${addDate}${lastMod}>${this.escapeHtml(node.title)}</H3>\n`;
+          html += `${indent}<DL><p>\n`;
+          if (node.children) {
+              for (const child of node.children) {
+                  html += this.nodeToHtml(child, indentLevel + 1);
+              }
+          }
+          html += `${indent}</DL><p>\n`;
+      }
+      return html;
+  }
+
+  private escapeHtml(text: string): string {
+      return text
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;")
+          .replace(/'/g, "&#039;");
+  }
+
+  public async importHtml(file: File): Promise<void> {
+      const text = await file.text();
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(text, 'text/html');
+
+      const importFolder = await this.bookmarksProvider.create({
+          parentId: '1',
+          title: `Imported HTML ${new Date().toLocaleString()}`
+      });
+
+      const dl = doc.querySelector('dl');
+      if (dl) {
+          await this.recursiveHtmlImport(dl, importFolder.id);
+      }
+  }
+
+  private async recursiveHtmlImport(dl: Element, parentId: string) {
+      const children = Array.from(dl.children);
+
+      for (let i = 0; i < children.length; i++) {
+          const node = children[i];
+
+          if (node.tagName === 'DT') {
+              const h3 = node.querySelector('h3');
+              const a = node.querySelector('a');
+
+              if (h3) {
+                  const title = h3.textContent || 'Untitled';
+                  const folder = await this.bookmarksProvider.create({
+                      parentId: parentId,
+                      title: title
+                  });
+
+                  // Look for internal DL first
+                  let internalDl = node.querySelector('dl');
+                  if (internalDl) {
+                      await this.recursiveHtmlImport(internalDl, folder.id);
+                  } else {
+                      // Look ahead for DL in siblings
+                      let nextIndex = i + 1;
+                      while (nextIndex < children.length) {
+                          const next = children[nextIndex];
+                          if (next.tagName === 'DL') {
+                              await this.recursiveHtmlImport(next, folder.id);
+                              i = nextIndex;
+                              break;
+                          } else if (next.tagName === 'DT') {
+                              break;
+                          }
+                          nextIndex++;
+                      }
+                  }
+              } else if (a) {
+                   const title = a.textContent || 'Untitled';
+                   const url = a.getAttribute('href');
+                   const tagsAttr = a.getAttribute('TAGS');
+
+                   if (url) {
+                      const bookmark = await this.bookmarksProvider.create({
+                          parentId: parentId,
+                          title: title,
+                          url: url
+                      });
+
+                      if (tagsAttr) {
+                          const tags = tagsAttr.split(',').map(t => t.trim()).filter(t => t);
+                          if (tags.length > 0) {
+                              this.tagsService.setTagsForBookmark(bookmark.id, tags);
+                              tags.forEach(tag => this.tagsService.addAvailableTag(tag));
+                          }
+                      }
+                   }
+              }
+          }
+      }
+  }
+}


### PR DESCRIPTION
Implemented import and export functionality for bookmarks.
- Users can now export their bookmarks to a JSON file (preserving tags and hierarchy) or a standard Netscape HTML file.
- Users can import bookmarks from JSON or HTML files.
- The HTML export includes a custom `TAGS` attribute to preserve tags when importing back into this application.
- Added E2E tests to verify the functionality.
- Updated the sidebar to include the "Import & Export" link.

---
*PR created automatically by Jules for task [9331320939688100270](https://jules.google.com/task/9331320939688100270) started by @klinki*